### PR TITLE
Allow read extra fields by regex

### DIFF
--- a/keepassphp/keepassphp.php
+++ b/keepassphp/keepassphp.php
@@ -573,15 +573,18 @@ abstract class KeePassPHP
 		$mkey->addKey($k);
 		return true;
 	}
-
-	/**
-	 * Opens a KeePass password database (.kdbx) file with the key $mkey.
-	 * @param $file The path of a KeePass password database file.
-	 * @param $mkey A master key.
-	 * @param &$error A string that will receive a message in case of error.
-	 * @return A new Database instance, or null in case of error.
-	 */
-	public static function openDatabaseFile($file, iKey $mkey, &$error)
+    
+    /**
+     * Opens a KeePass password database (.kdbx) file with the key $mkey.
+     *
+     * @param string      $file         The path of a KeePass password database file.
+     * @param iKey        $mkey         A master key.
+     * @param string      &$error       A string that will receive a message in case of error.
+     * @param bool|string $extra_fields [optional] A string with a regular expression for the include extra fields
+     *
+     * @return Database A new Database instance, or null in case of error.
+     */
+	public static function openDatabaseFile($file, iKey $mkey, &$error, $extra_fields = false)
 	{
 		$reader = ResourceReader::openFile($file);
 		if($reader == null)
@@ -589,7 +592,7 @@ abstract class KeePassPHP
 			$error = "file '" . $file . '" does not exist.';
 			return null;
 		}
-		$db = Database::loadFromKdbx($reader, $mkey, $error);
+		$db = Database::loadFromKdbx($reader, $mkey, $error, $extra_fields);
 		$reader->close();
 		return $db;
 	}

--- a/keepassphp/lib/group.php
+++ b/keepassphp/lib/group.php
@@ -167,14 +167,17 @@ class Group
 		}
 		return $group;
 	}
-
-	/**
-	 * Creates a new Group instance from a ProtectedXMLReader instance reading
-	 * a KeePass 2.x database and located at a Group element node.
-	 * @param $reader A XML reader.
-	 * @return A Group instance if the parsing went okay, null otherwise.
-	 */
-	public static function loadFromXML(ProtectedXMLReader $reader)
+    
+    /**
+     * Creates a new Group instance from a ProtectedXMLReader instance reading
+     * a KeePass 2.x database and located at a Group element node.
+     *
+     * @param ProtectedXMLReader $reader       A XML reader.
+     * @param bool|string        $extra_fields [optional] A string with a regular expression for the include extra fields
+     *
+     * @return Group A Group instance if the parsing went okay, null otherwise.
+     */
+	public static function loadFromXML(ProtectedXMLReader $reader, $extra_fields = false)
 	{
 		if($reader == null)
 			return null;
@@ -183,9 +186,9 @@ class Group
 		while($reader->read($d))
 		{
 			if($reader->isElement(Database::XML_GROUP))
-				$group->addGroup(Group::loadFromXML($reader));
+				$group->addGroup(Group::loadFromXML($reader, $extra_fields));
 			elseif($reader->isElement(Database::XML_ENTRY))
-				$group->addEntry(Entry::loadFromXML($reader));
+				$group->addEntry(Entry::loadFromXML($reader, $extra_fields));
 			elseif($reader->isElement(Database::XML_UUID))
 				$group->uuid = $reader->readTextInside();
 			elseif($reader->isElement(Database::XML_NAME))


### PR DESCRIPTION
Example:
Read without extra fields:
KeePassPHP::openDatabaseFile($path_to_database_file, $composite_key, $error));
or
KeePassPHP::openDatabaseFile($path_to_database_file, $composite_key, $error, false));

Read all extra fields:
KeePassPHP::openDatabaseFile($path_to_database_file, $composite_key, $error, "/.*/"));

Read extra fields, contains "eur" or "usd" in name (case insensitive):
KeePassPHP::openDatabaseFile($path_to_database_file, $composite_key, $error, "/(eur|usd)/i"));

Read extra fields, beginning "newBranch" in name (case sensitivity):
KeePassPHP::openDatabaseFile($path_to_database_file, $composite_key, $error, "/^newBranch.*/"));